### PR TITLE
fix config parsing error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-diag-collect (1.4.1) stable; urgency=medium
+
+  * fix config parsing error
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Tue, 11 Oct 2022 14:41:20 +0500
+
 wb-diag-collect (1.4.0) stable; urgency=medium
 
   * Support connection to Mosquitto through unix socket

--- a/wb/diag/diag_collect.py
+++ b/wb/diag/diag_collect.py
@@ -56,7 +56,7 @@ def main(argv=sys.argv):
 
             if args.server:
                 options["broker"] = yaml_data["mqtt"]["broker"]
-                options["port"] = yaml_data["mqtt"]["port"]
+                options["port"] = yaml_data["mqtt"].get("port", 0)
 
         if args.server:
             rpc_server.serve(options, logger)


### PR DESCRIPTION
Для bullseye в конфиге не задаётся порт, т.к. общение идёт через unix-сокет