### PR TITLE
add dependency on mosquitto.service to wait for UNIX socket file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildDebSbuild defaultTargets: 'bullseye-host'
+buildDebArchAll defaultDebianRelease: 'bullseye'

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-diag-collect (1.4.2) stable; urgency=medium
+
+  * add dependency on mosquitto.service to wait for UNIX socket file
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 09 Nov 2022 19:38:56 +0600
+
 wb-diag-collect (1.4.1) stable; urgency=medium
 
   * fix config parsing error

--- a/debian/wb-diag-collect.service
+++ b/debian/wb-diag-collect.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=one-click diagnostic data collector for Wiren Board, generating archive with data
-Wants=wb-hwconf-manager.service wb-modules.service
-After=wb-hwconf-manager.service wb-modules.service
+After=wb-hwconf-manager.service mosquitto.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
Предотвращает многократные перезапуски сервиса в bullseye, где подключение сначала пробуется через UNIX-сокет