### PR TITLE
fix high CPU load on broker reconnections

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-diag-collect (1.4.3) stable; urgency=medium
+
+  * fix high CPU load on broker reconnections
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 23 Nov 2022 21:39:35 +0600
+
 wb-diag-collect (1.4.2) stable; urgency=medium
 
   * add dependency on mosquitto.service to wait for UNIX socket file

--- a/wb/diag/rpc_server.py
+++ b/wb/diag/rpc_server.py
@@ -13,6 +13,8 @@ from paho.mqtt import client as mqttclient
 
 from wb.diag import collector
 
+EXIT_FAILURE = 1
+
 
 class MQTTRPCServer:
     def __init__(self, options, dispatcher, logger):
@@ -50,14 +52,11 @@ class MQTTRPCServer:
         self.wb_archive_collector = collector.Collector(logger)
 
     def _on_connect(self, client, userdata, flags, rc, *_):
-        # TODO: more graceful exit here + guideline
+        # TODO: graceful exit here + guideline
         # https://wirenboard.bitrix24.ru/workgroups/group/218/tasks/task/view/55510/
         if rc != 0:
-            if rc in [4, 5]:
-                self.logger.error("MQTT broker authorization failed, code %d", rc)
-                sys.exit(6)  # NOTCONFIGURED, will not restart automatically
-            else:
-                self.logger.error("MQTT broker connection failed, code %d", rc)
+            self.logger.error("MQTT broker connection failed, code %d", rc)
+            sys.exit(EXIT_FAILURE)
 
         self.logger.debug("Settings up RPC endpoints")
         for service, method in self.dispatcher.keys():

--- a/wb/diag/rpc_server.py
+++ b/wb/diag/rpc_server.py
@@ -2,6 +2,8 @@ import logging
 import os
 import signal
 import subprocess
+import sys
+import threading
 import urllib.parse
 from contextlib import contextmanager
 
@@ -22,34 +24,48 @@ class MQTTRPCServer:
         self.dispatcher.add_method(self.diag)
         self.dispatcher.add_method(self.status)
 
+        self._stop_event = threading.Event()
+
         broker = options["broker"]
         url = urllib.parse.urlparse(broker)
         if url.scheme == "unix":
             logger.debug("Connecting to broker %s", broker)
             self.client = paho_socket.Client("wb-diag-collect")
-            self.client.on_message = self.on_message
+            self.client.on_message = self._on_message
+            self.client.on_connect = self._on_connect
             self.client.sock_connect(url.path)
         else:
             port = options["port"]
             logger.debug("Connecting to broker %s:%s", broker, port)
             self.client = mqttclient.Client("wb-diag-collect")
-            self.client.on_message = self.on_message
+            self.client.on_message = self._on_message
+            self.client.on_connect = self._on_connect
             self.client.connect(broker, port)
 
-        self.run = True
+        self.client.loop_start()
 
-        signal.signal(signal.SIGINT, self.stop)
-        signal.signal(signal.SIGTERM, self.stop)
+        signal.signal(signal.SIGINT, self._signal)
+        signal.signal(signal.SIGTERM, self._signal)
 
         self.wb_archive_collector = collector.Collector(logger)
 
-    def setup(self):
+    def _on_connect(self, client, userdata, flags, rc, *_):
+        # TODO: more graceful exit here + guideline
+        # https://wirenboard.bitrix24.ru/workgroups/group/218/tasks/task/view/55510/
+        if rc != 0:
+            if rc in [4, 5]:
+                self.logger.error("MQTT broker authorization failed, code %d", rc)
+                sys.exit(6)  # NOTCONFIGURED, will not restart automatically
+            else:
+                self.logger.error("MQTT broker connection failed, code %d", rc)
+
+        self.logger.debug("Settings up RPC endpoints")
         for service, method in self.dispatcher.keys():
             self.client.publish("/rpc/v1/%s/%s/%s" % (self.driver_id, service, method), "1", retain=True)
             self.logger.debug("Subscribe to /rpc/v1/%s/%s/%s/+", self.driver_id, service, method)
             self.client.subscribe("/rpc/v1/%s/%s/%s/+" % (self.driver_id, service, method))
 
-    def on_message(self, mosq, obj, msg):
+    def _on_message(self, mosq, obj, msg):
         parts = msg.topic.split("/")
         service_id = parts[4]
         method_id = parts[5]
@@ -86,33 +102,42 @@ class MQTTRPCServer:
         except OSError as e:
             print("OSError: with file %s, errno %d", e.filename, e.errno)
 
-    def loop(self):
-        self.client.loop()
+    def wait_for_stop(self):
+        self._stop_event.wait()
 
-    def stop(self, *args):
+    def _signal(self, *_):
         self.logger.debug("Asynchronous interrupt, stopping")
-        for service, method in self.dispatcher.keys():
-            self.client.publish("/rpc/v1/%s/%s/%s" % (self.driver_id, service, method), retain=True)
+        self._stop_event.set()
 
-        # timeout in last loop for publish execution control
-        self.client.loop(timeout=1.0)
+    def stop(self):
+        try:
+            self.logger.debug("Cleaning up retains")
 
-        self.run = False
-        self.logger.debug("Disconnecting with broker")
-        self.client.disconnect()
+            pubs = []
+            for service, method in self.dispatcher.keys():
+                pubs.append(
+                    self.client.publish("/rpc/v1/%s/%s/%s" % (self.driver_id, service, method), retain=True)
+                )
+            for pub in pubs:
+                pub.wait_for_publish()
+
+            self.logger.debug("Disconnecting from broker")
+            self.client.disconnect()
+        finally:
+            self.client.loop_stop()
 
 
 @contextmanager
 def rpc_server_context(name, options, dispatcher, logger):
     try:
         rpc_server = MQTTRPCServer(options, dispatcher, logger)
-        rpc_server.setup()
         yield rpc_server
-    except (TimeoutError, ConnectionRefusedError) as error:
-        logger.debug("Cannot connect to broker %s:%s", options["broker"], options["port"])
+    except (TimeoutError, ConnectionRefusedError):
+        logger.error("Cannot connect to broker %s:%s", options["broker"], options["port"], exc_info=True)
+    finally:
+        rpc_server.stop()
 
 
 def serve(options, logger):
     with rpc_server_context("wb-diag-collect", options, dispatcher, logger) as server:
-        while server.run:
-            server.loop()
+        server.wait_for_stop()

--- a/wb/diag/rpc_server.py
+++ b/wb/diag/rpc_server.py
@@ -2,12 +2,12 @@ import logging
 import os
 import signal
 import subprocess
-from contextlib import contextmanager
 import urllib.parse
+from contextlib import contextmanager
 
+import paho_socket
 from mqttrpc import MQTTRPCResponseManager, dispatcher
 from paho.mqtt import client as mqttclient
-import paho_socket
 
 from wb.diag import collector
 
@@ -24,7 +24,7 @@ class MQTTRPCServer:
 
         broker = options["broker"]
         url = urllib.parse.urlparse(broker)
-        if url.scheme == 'unix':
+        if url.scheme == "unix":
             logger.debug("Connecting to broker %s", broker)
             self.client = paho_socket.Client("wb-diag-collect")
             self.client.on_message = self.on_message


### PR DESCRIPTION
It was caused by wrong assumption about paho.mqtt's loop() about its behavior on disconnects. It does not try to restore connection, but loop_forever() (and so loop_start()/loop_stop()) does.
    
This commit switches service to use loop_start()/loop_stop() and adds on_connect() handler to restore subscriptions and metainfo after mosquitto restart.
    
I also wrote a guideline about graceful usage of paho.mqtt loop, see https://github.com/wirenboard/codestyle/pull/34