### PR TITLE
add systemctl list-unit-files output to determine disabled units

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-diag-collect (1.5.4) stable; urgency=medium
+
+  * add systemctl list-unit-files output to determine disabled units
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 14 Mar 2023 16:45:30 +0600
+
 wb-diag-collect (1.5.3) stable; urgency=medium
 
   * Use mqtt client wrapper from wb-common

--- a/wb-diag-collect.conf
+++ b/wb-diag-collect.conf
@@ -45,6 +45,9 @@ commands:
       filename: service/systemd_units
       command: 'systemctl list-units --all --output=json'
     -
+      filename: service/systemd_unit_files
+      command: 'systemctl list-unit-files --all --output=json'
+    -
       filename: uptime
       command: uptime
     -


### PR DESCRIPTION
Понял, что в архиве не хватало информации о disabled-юнитах, потому что она не выводится через `systemctl list-units`. Добавил, заодно тут же будет информация о замаскированных юнитах.