### PR TITLE
Update wb-diag-collect.conf

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-diag-collect (1.5.7) stable; urgency=medium
+
+  * Fix parsing wb-mqtt-serial.conf with comments
+  * Collect wpa_supplicant.service logs
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 12 Apr 2023 13:11:00 +0400
+
 wb-diag-collect (1.5.6) stable; urgency=medium
 
   * Hide passwords from wb-mqtt-serial.conf

--- a/wb-diag-collect.conf
+++ b/wb-diag-collect.conf
@@ -12,6 +12,7 @@ journald_logs:
     - nginx.service
     - NetworkManager.service
     - ModemManager.service
+    - wpa_supplicant.service
 
 commands:
     -
@@ -103,7 +104,7 @@ commands:
       command: 'nmcli'
     -
       filename: etc/wb-mqtt-serial.conf
-      command: "jq '.ports[].devices[] |= if has(\"password\") then .password = \"REMOVED_BY_DIAG_COLLECT\" else . end' /etc/wb-mqtt-serial.conf"
+      command: "sed 's#^\\s*//.*##' /etc/wb-mqtt-serial.conf | jq '.ports[].devices[] |= if has(\"password\") then .password = \"REMOVED_BY_DIAG_COLLECT\" else . end'"
 
 files:
     - /etc/apt/sources.list*


### PR DESCRIPTION
 * Fix parsing wb-mqtt-serial.conf with comments
 * Collect wpa_supplicant.service logs

Если конфиг сириала не редактировали через UI, то он не является валидным JSON так как содержит коментарий:
```sh
$ head -n2 /etc/wb-mqtt-serial.conf
// Configuration options
{
```