### PR TITLE
Remove emmcparm proprietary options for Micron flash drive

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-diag-collect (1.5.8) stable; urgency=medium
+
+  * Remove emmcparm proprietary options for Micron flash drive
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Thu, 18 May 2023 13:42:16 +0300
+
 wb-diag-collect (1.5.7) stable; urgency=medium
 
   * Fix parsing wb-mqtt-serial.conf with comments

--- a/wb-diag-collect.conf
+++ b/wb-diag-collect.conf
@@ -83,7 +83,7 @@ commands:
       command: 'cat /sys/kernel/debug/mmc0/ios'
     -
       filename: emmc/emmcparm
-      command: 'emmcparm -V -I -t -B -S  -E -e /dev/mmcblk0'
+      command: 'emmcparm -I /dev/mmcblk0'
     -
       filename: wb-release
       command: 'journalctl -t wb-release -n 1000 --no-pager'


### PR DESCRIPTION
подробно: emmcparm  - то утилита, которая проприетарные команды Micron шлёт. Мы уже больше года ни одной штуки на микроне не выпустили, скорее всего у Саши не микрон. Нормально, если флешка не смогла что-то там обработать и даже если с ума сошла, то терпимо. Поэтому хорошо бы emmcparm не дёргать и посмотреть как будет

а -I это просто стандартная информация, она у всех флешек есть. Остальные флажки проприетарные для памяти Микрон