### PR TITLE
Fix pkg-info

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2021-2023 Contactless Devices, LLC (Wiren Board)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-diag-collect (1.6.1) stable; urgency=medium
+
+  * Fix PKG-INFO
+  * Add LICENSE
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 14 Jul 2023 16:39:00 +0400
+
 wb-diag-collect (1.6.0) stable; urgency=medium
 
   * Collect /etc/mosquitto/{mosquitto.conf,acl/*.conf,conf.d/*.conf}

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,21 @@
 
 from setuptools import setup
 
+
+def get_version():
+    with open("debian/changelog", "r") as f:
+        return f.readline().split()[1][1:-1]
+
+
 setup(
     name="wb-diag-collect",
-    version="1.4.0",
+    version=get_version(),
     description="Diagnostic collector",
+    license="MIT",
     author="Sokolov Semen",
     author_email="s.sokolov@wirenboard.ru",
+    maintainer="Wiren Board Team",
+    maintainer_email="info@wirenboard.com",
+    url="https://github.com/wirenboard/wb-diag-collect",
     packages=["wb.diag"],
 )


### PR DESCRIPTION
Before:
```sh
$ cat /usr/lib/python3/dist-packages/wb_diag_collect-1.4.0.egg-info/PKG-INFO
Metadata-Version: 1.0
Name: wb-diag-collect
Version: 1.4.0
Summary: Diagnostic collector
Home-page: UNKNOWN
Author: Sokolov Semen
Author-email: s.sokolov@wirenboard.ru
License: UNKNOWN
Description: UNKNOWN
Platform: UNKNOWN
```
 After:
```sh
$ cat /usr/lib/python3/dist-packages/wb_diag_collect-1.6.1.egg-info/PKG-INFO
Metadata-Version: 1.2
Name: wb-diag-collect
Version: 1.6.1
Summary: Diagnostic collector
Home-page: https://github.com/wirenboard/wb-diag-collect
Author: Sokolov Semen
Author-email: s.sokolov@wirenboard.ru
Maintainer: Wiren Board Team
Maintainer-email: info@wirenboard.com
License: MIT
Description: UNKNOWN
Platform: UNKNOWN
```