### PR TITLE
Collect factoryreset.fit meta info

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-diag-collect (1.6.2) stable; urgency=medium
+
+  * Collect factoryreset.fit meta info
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 25 Jul 2023 19:21:00 +0400
+
 wb-diag-collect (1.6.1) stable; urgency=medium
 
   * Fix PKG-INFO

--- a/wb-diag-collect.conf
+++ b/wb-diag-collect.conf
@@ -43,6 +43,9 @@ commands:
       filename: dtc
       command: 'dtc -I fs -O dts /proc/device-tree'
     -
+      filename: factoryreset.fit-meta
+      command: 'fdtget /mnt/data/.wb-restore/factoryreset.fit / timestamp / description / compatible / firmware-version / firmware-compatible / release-name / release-suite / release-target / release-repo-prefix'
+    -
       filename: service/systemd_units
       command: 'systemctl list-units --all --output=json'
     -


### PR DESCRIPTION
```sh
$ fdtget /mnt/data/.wb-restore/factoryreset.fit / timestamp / description / compatible / firmware-version / firmware-compatible / release-name / release-suite / release-target / release-repo-prefix
1681913347
WirenBoard firmware update
wirenboard,wirenboard-720
202304191406
+single-rootfs
unstable.latest
testing
wb7/bullseye
0
```