### PR TITLE
Add transitional dummy package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,12 @@
+wb-diag-collect (1.7.1) stable; urgency=medium
+
+  * Add transitional dummy package, no functional changes
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 26 Jul 2023 17:21:00 +0400
+
 wb-diag-collect (1.7.0) stable; urgency=medium
 
-  * Remove python3-wb-diag-collect deb package
+  * Remove python3-wb-diag-collect deb package, no functional changes
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 26 Jul 2023 12:59:00 +0400
 

--- a/debian/control
+++ b/debian/control
@@ -7,11 +7,18 @@ Standards-Version: 4.5.0
 Homepage: https://github.com/wirenboard/wb-diag-collect
 X-Python3-Version: >= 3.5
 
+Package: python3-wb-diag-collect
+Section: python
+Architecture: all
+Depends: wb-diag-collect (>= 1.7.0)
+Description: transitional dummy package
+ This is a transitional dummy package. It can safely be removed.
+
 Package: wb-diag-collect
 Architecture: all
 Multi-Arch: foreign
-Breaks: python3-wb-diag-collect
-Replaces: python3-wb-diag-collect
+Breaks: python3-wb-diag-collect (<< 1.7.0)
+Replaces: python3-wb-diag-collect (<< 1.7.0)
 Provides: python3-wb-diag-collect
 Depends: ${misc:Depends}, ${python3:Depends}, python3-yaml, python3-mqttrpc, python3-wb-common (>= 2.1.0), emmcparm (>= 5.0.0), mqtt-tools
 Description: one-click diagnostic data collector for Wiren Board,


### PR DESCRIPTION
Сейчас при `apt upgrade` у пользователя diag-collect не обновляется:
```sh
The following packages have been kept back:
  python3-wb-diag-collect wb-diag-collect
```
Приходится выполнять `apt dist-upgrade`.
https://wiki.debian.org/PackageTransition