### PR TITLE
Fix single package scheme

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-diag-collect (1.7.2) stable; urgency=medium
+
+  * fix dummy package
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Mon, 31 Jul 2023 15:01:57 +0600
+
 wb-diag-collect (1.7.1) stable; urgency=medium
 
   * Add transitional dummy package, no functional changes

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
-export PYBUILD_NAME=wb-diag-collect
+export PYBUILD_INSTALL_ARGS=--install-lib=/usr/share/wb-diag-collect/ --install-scripts=/usr/share/wb-diag-collect/
+export PYBUILD_DESTDIR_python3=debian/wb-diag-collect
 
 %:
 	dh $@ --with python3 --buildsystem pybuild

--- a/wb-diag-collect
+++ b/wb-diag-collect
@@ -2,6 +2,10 @@
 
 import sys
 
+# this is recommended by Debian Python Policy
+# see https://www.debian.org/doc/packaging-manuals/python-policy/index.html#programs-shipping-private-modules
+sys.path.append("/usr/share/wb-diag-collect")
+
 from wb.diag.diag_collect import main
 
 sys.exit(main())


### PR DESCRIPTION
Починил объединение пакета с утилитой и бинарником, для этого пришлось почитать исходники pybuild.

Рекомендацию по перемещению библиотеки в приватное место вычитал тут: https://www.debian.org/doc/packaging-manuals/python-policy/index.html#programs-shipping-private-modules