### PR TITLE
collect nginx logs and FIT update wb-console.log

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-diag-collect (1.8.1) stable; urgency=medium
+
+  * Collect nginx logs and FIT update wb-console.log
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Wed, 23 Aug 2023 15:01:57 +0600
+
 wb-diag-collect (1.8.0) stable; urgency=medium
 
   * Add Embedded Controller files

--- a/wb-diag-collect.conf
+++ b/wb-diag-collect.conf
@@ -138,6 +138,8 @@ files:
     - /var/log/z-way-server.log
     - /var/log/mosquitto/mosquitto.log
     - /var/log/apt/history.log
+    - /var/log/nginx/*.log
+    - /var/log/nginx/*.log.1*
 
 filters:
     -


### PR DESCRIPTION
Логи nginx давно надо было добавить, а wb-console.log растёт отсюда: https://github.com/wirenboard/wb-utils/pull/123