### PR TITLE
Set LC_ALL=C for all commands

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-diag-collect (1.8.17) stable; urgency=medium
+
+  * Set LC_ALL=C for all commands
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 22 Oct 2024 16:13:00 +0400
+
 wb-diag-collect (1.8.16) stable; urgency=medium
 
   * Enable angry pylint. No functional changes

--- a/wb/diag/collector.py
+++ b/wb/diag/collector.py
@@ -154,7 +154,7 @@ class Collector:
                 command = f"journalctl -u {service} --no-pager -n {lines_count}"
                 try:
                     with subprocess.Popen(
-                        command, env=env, shell=True, stdout=file, stderr=subprocess.STDOUT
+                        command, env=env, shell=True, stdout=file, stderr=subprocess.STDOUT  # nosec B602
                     ) as proc:
                         proc.wait(timeout)
                 except subprocess.TimeoutExpired:

--- a/wb/diag/collector.py
+++ b/wb/diag/collector.py
@@ -114,7 +114,7 @@ class Collector:
             with open(f"{directory}/{file_name}.log", "w", encoding="utf-8") as file:
                 try:
                     with subprocess.Popen(
-                        command, env=env, shell=True, stdout=file, stderr=subprocess.STDOUT
+                        command, env=env, shell=True, stdout=file, stderr=subprocess.STDOUT  # nosec B602
                     ) as proc:
                         proc.wait(timeout)
                 except subprocess.TimeoutExpired:

--- a/wb/diag/collector.py
+++ b/wb/diag/collector.py
@@ -102,6 +102,9 @@ class Collector:
                     f.truncate()
 
     def execute_commands(self, directory, commands, timeout):
+        env = os.environ.copy()
+        env["LC_ALL"] = "C"
+
         for command_data in commands:
             command = command_data["command"]
             file_name = command_data["filename"]
@@ -110,7 +113,9 @@ class Collector:
 
             with open(f"{directory}/{file_name}.log", "w", encoding="utf-8") as file:
                 try:
-                    with subprocess.Popen(command, shell=True, stdout=file, stderr=subprocess.STDOUT) as proc:
+                    with subprocess.Popen(
+                        command, env=env, shell=True, stdout=file, stderr=subprocess.STDOUT
+                    ) as proc:
                         proc.wait(timeout)
                 except subprocess.TimeoutExpired:
                     self.logger.warning(
@@ -121,9 +126,12 @@ class Collector:
                     )
 
     def copy_journalctl(self, directory, service_wildcards, lines_count, timeout):
+        env = os.environ.copy()
+        env["LC_ALL"] = "C"
 
         with subprocess.Popen(
             "systemctl list-unit-files --no-pager | grep .service",
+            env=env,
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
@@ -145,7 +153,9 @@ class Collector:
             with open(f"{directory}/service/{service}.log", "w", encoding="utf-8") as file:
                 command = f"journalctl -u {service} --no-pager -n {lines_count}"
                 try:
-                    with subprocess.Popen(command, shell=True, stdout=file, stderr=subprocess.STDOUT) as proc:
+                    with subprocess.Popen(
+                        command, env=env, shell=True, stdout=file, stderr=subprocess.STDOUT
+                    ) as proc:
                         proc.wait(timeout)
                 except subprocess.TimeoutExpired:
                     self.logger.warning(


### PR DESCRIPTION
Иногда у пользователей выставлена русская локаль, это неудобно при дальнейшем разборе логов:

<img width="962" alt="Näyttökuva 2024-10-22 kello 15 50 53" src="https://github.com/user-attachments/assets/c67a5740-5947-4f1b-82bc-8338cc54786f">
