### PR TITLE
Feature/soft 4565 make async

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-diag-collect (1.9.0) stable; urgency=medium
+
+  * Rework internals to asyncio
+  * Fix mqtt rpc timeout on collecting diag from high-loaded controllers
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 20 Feb 2025 18:29:02 +0300
+
 wb-diag-collect (1.8.18) stable; urgency=medium
 
   * Add mmcli -m wbc

--- a/debian/changelog
+++ b/debian/changelog
@@ -284,13 +284,13 @@ wb-diag-collect (1.0.0) stable; urgency=low
 
  -- Evgeny Boger <boger@wirenboard.com>  Sun, 21 Nov 2021 22:56:15 +0300
 
-wb-diag-collect (0.2) UNRELEASED; urgency=low
+wb-diag-collect (0.2) unstable; urgency=low
 
   * Cleaning topics on service stop.
 
  -- Semen Sokolov <s.sokolov@wirenboard.ru>  Fri, 30 Sep 2021 03:25:44 +0300
 
-wb-diag-collect (0.1) UNRELEASED; urgency=low
+wb-diag-collect (0.1) unstable; urgency=low
 
   * Initial release. Ticket #38500
 

--- a/debian/control
+++ b/debian/control
@@ -21,5 +21,6 @@ Breaks: python3-wb-diag-collect (<< 1.7.0)
 Replaces: python3-wb-diag-collect (<< 1.7.0)
 Provides: python3-wb-diag-collect
 Depends: ${misc:Depends}, ${python3:Depends}, python3-yaml, python3-mqttrpc, python3-wb-common (>= 2.1.0), emmcparm (>= 5.0.0), mqtt-tools
+Recommends: wb-mqtt-homeui (>= 2.110.0~~)
 Description: one-click diagnostic data collector for Wiren Board,
  generating archive with data

--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,6 @@ Breaks: python3-wb-diag-collect (<< 1.7.0)
 Replaces: python3-wb-diag-collect (<< 1.7.0)
 Provides: python3-wb-diag-collect
 Depends: ${misc:Depends}, ${python3:Depends}, python3-yaml, python3-mqttrpc, python3-wb-common (>= 2.1.0), emmcparm (>= 5.0.0), mqtt-tools
-Recommends: wb-mqtt-homeui (>= 2.110.0~~)
+Recommends: wb-mqtt-homeui (>= 2.111.0~~)
 Description: one-click diagnostic data collector for Wiren Board,
  generating archive with data

--- a/debian/rules
+++ b/debian/rules
@@ -4,4 +4,8 @@ export PYBUILD_INSTALL_ARGS=--install-lib=/usr/share/wb-diag-collect/ --install-
 export PYBUILD_DESTDIR_python3=debian/wb-diag-collect
 
 %:
-	dh $@ --with python3 --buildsystem pybuild
+	dh $@ --with python3 --buildsystem=pybuild
+
+override_dh_installinit:
+	dh_installinit --noscripts
+

--- a/debian/wb-diag-collect.lintian-overrides
+++ b/debian/wb-diag-collect.lintian-overrides
@@ -1,0 +1,2 @@
+wb-diag-collect: dir-or-file-in-var-www var/www/diag/
+wb-diag-collect: dir-or-file-in-var-www var/www/diag/.htaccess

--- a/wb/diag/collector.py
+++ b/wb/diag/collector.py
@@ -1,10 +1,10 @@
+import asyncio
 import datetime
 import glob
 import logging
 import os
 import re
 import shutil
-import subprocess
 from fnmatch import fnmatch
 from io import StringIO
 from tempfile import TemporaryDirectory
@@ -16,7 +16,7 @@ class Collector:
         self.log_stream = None
         self.log_stream_handler = None
 
-    def collect(self, options, output_directory, output_filename):
+    async def collect(self, options, output_directory, output_filename):
         with TemporaryDirectory() as tmpdir:
             try:
                 self.log_stream = StringIO()
@@ -27,10 +27,10 @@ class Collector:
                 )
                 self.logger.addHandler(self.log_stream_handler)
 
-                self.copy_files(tmpdir, options["files"])
+                await self.copy_files(tmpdir, options["files"])
                 self.filter_files(tmpdir, options["filters"])
-                self.execute_commands(tmpdir, options["commands"], options["timeout"])
-                self.copy_journalctl(
+                await self.execute_commands(tmpdir, options["commands"], options["timeout"])
+                await self.copy_journalctl(
                     tmpdir, options["service_names"], options["service_lines_number"], options["timeout"]
                 )
 
@@ -61,33 +61,34 @@ class Collector:
                 root_dir=tmpdir,
             )
 
-    def apply_file_wildcard(self, wildcard: str, timeout):
+    async def apply_file_wildcard(self, wildcard: str, timeout):
         try:
-            with subprocess.Popen(
+            proc = await asyncio.create_subprocess_shell(
                 f"find {wildcard} -type f,l",
                 shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-            ) as proc:
-                if proc.wait(timeout) != 0:
-                    self.logger.debug("No files for wildcard %s", wildcard)
-                    return []
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+            rc = await asyncio.wait_for(proc.wait(), timeout=timeout)
+            if rc != 0:
+                self.logger.debug("No files for wildcard %s", wildcard)
+                return []
 
-                file_paths = []
-                cmd_res = proc.stdout.readlines()
+            file_paths = []
+            cmd_res = await proc.stdout.read()
 
-                for line in cmd_res:
-                    path = line.decode().strip()
-                    file_paths.append(path)
+            for line in cmd_res.splitlines():
+                path = line.decode().strip()
+                file_paths.append(path)
 
-                return file_paths
-        except subprocess.TimeoutExpired:
+            return file_paths
+        except TimeoutError:
             self.logger.warning("Timeout was expired for wildcard %s", wildcard)
             return []
 
-    def copy_files(self, directory, wildcards):
+    async def copy_files(self, directory, wildcards):
         for wildcard in wildcards:
-            file_paths = self.apply_file_wildcard(wildcard, 1.0) or []
+            file_paths = await self.apply_file_wildcard(wildcard, 1.0) or []
             for path in file_paths:
                 os.makedirs(f"{directory}/{os.path.dirname(path)}", exist_ok=True)
                 shutil.copyfile(path, f"{directory}/{path}")
@@ -101,7 +102,7 @@ class Collector:
                     f.write(content)
                     f.truncate()
 
-    def execute_commands(self, directory, commands, timeout):
+    async def execute_commands(self, directory, commands, timeout):
         env = os.environ.copy()
         env["LC_ALL"] = "C"
 
@@ -113,11 +114,9 @@ class Collector:
 
             with open(f"{directory}/{file_name}.log", "w", encoding="utf-8") as file:
                 try:
-                    with subprocess.Popen(
-                        command, env=env, shell=True, stdout=file, stderr=subprocess.STDOUT  # nosec B602
-                    ) as proc:
-                        proc.wait(timeout)
-                except subprocess.TimeoutExpired:
+                    proc = await asyncio.create_subprocess_shell(cmd=command, shell=True, env=env, stdout=file, stderr=asyncio.subprocess.STDOUT) # nosec B602
+                    await asyncio.wait_for(proc.wait(), timeout=timeout)
+                except TimeoutError:
                     self.logger.warning(
                         "Command %s didn't finish in %ds",
                         command,
@@ -125,18 +124,18 @@ class Collector:
                         exc_info=(self.logger.level <= logging.DEBUG),
                     )
 
-    def copy_journalctl(self, directory, service_wildcards, lines_count, timeout):
+    async def copy_journalctl(self, directory, service_wildcards, lines_count, timeout):
         env = os.environ.copy()
         env["LC_ALL"] = "C"
 
-        with subprocess.Popen(
-            "systemctl list-unit-files --no-pager | grep .service",
+        proc = await asyncio.create_subprocess_shell(
+            cmd="systemctl list-unit-files --no-pager | grep .service",
             env=env,
-            shell=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-        ) as proc:
-            cmd_res = proc.stdout.readlines()
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout, _ = await proc.communicate()
+        cmd_res = stdout.splitlines()
 
         services = []
         for line in cmd_res:
@@ -153,11 +152,11 @@ class Collector:
             with open(f"{directory}/service/{service}.log", "w", encoding="utf-8") as file:
                 command = f"journalctl -u {service} --no-pager -n {lines_count}"
                 try:
-                    with subprocess.Popen(
-                        command, env=env, shell=True, stdout=file, stderr=subprocess.STDOUT  # nosec B602
-                    ) as proc:
-                        proc.wait(timeout)
-                except subprocess.TimeoutExpired:
+                    proc = await asyncio.create_subprocess_shell(
+                        command, env=env, shell=True, stdout=file, stderr=asyncio.subprocess.STDOUT  # nosec B602
+                    )
+                    await asyncio.wait_for(proc.wait(), timeout=timeout)
+                except TimeoutError:
                     self.logger.warning(
                         "Journalctl reading %s didn't finish in %ds",
                         command,

--- a/wb/diag/collector.py
+++ b/wb/diag/collector.py
@@ -114,7 +114,9 @@ class Collector:
 
             with open(f"{directory}/{file_name}.log", "w", encoding="utf-8") as file:
                 try:
-                    proc = await asyncio.create_subprocess_shell(cmd=command, shell=True, env=env, stdout=file, stderr=asyncio.subprocess.STDOUT) # nosec B602
+                    proc = await asyncio.create_subprocess_shell(
+                        cmd=command, shell=True, env=env, stdout=file, stderr=asyncio.subprocess.STDOUT
+                    )  # nosec B602
                     await asyncio.wait_for(proc.wait(), timeout=timeout)
                 except TimeoutError:
                     self.logger.warning(
@@ -124,7 +126,9 @@ class Collector:
                         exc_info=(self.logger.level <= logging.DEBUG),
                     )
 
-    async def copy_journalctl(self, directory, service_wildcards, lines_count, timeout):
+    async def copy_journalctl(
+        self, directory, service_wildcards, lines_count, timeout
+    ):  # pylint:disable=too-many-locals
         env = os.environ.copy()
         env["LC_ALL"] = "C"
 
@@ -153,7 +157,11 @@ class Collector:
                 command = f"journalctl -u {service} --no-pager -n {lines_count}"
                 try:
                     proc = await asyncio.create_subprocess_shell(
-                        command, env=env, shell=True, stdout=file, stderr=asyncio.subprocess.STDOUT  # nosec B602
+                        command,
+                        env=env,
+                        shell=True,
+                        stdout=file,
+                        stderr=asyncio.subprocess.STDOUT,  # nosec B602
                     )
                     await asyncio.wait_for(proc.wait(), timeout=timeout)
                 except TimeoutError:

--- a/wb/diag/collector.py
+++ b/wb/diag/collector.py
@@ -62,9 +62,10 @@ class Collector:
             )
 
     async def apply_file_wildcard(self, wildcard: str, timeout):
+        cmd = f"find {wildcard} -type f,l"
         try:
             proc = await asyncio.create_subprocess_shell(
-                f"find {wildcard} -type f,l",
+                cmd=cmd,
                 shell=True,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.STDOUT,

--- a/wb/diag/diag_collect.py
+++ b/wb/diag/diag_collect.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 import logging
 import sys
 from enum import IntEnum
@@ -67,7 +68,7 @@ def main(argv=sys.argv):
             print("Start data collecting")
 
             wb_archive_collector = collector.Collector(logger)
-            wb_archive_collector.collect(options, "", args.output_filename[0])
+            asyncio.get_event_loop().run_until_complete(wb_archive_collector.collect(options, "", args.output_filename[0]))
 
             print("Data was collected successfully")
 

--- a/wb/diag/diag_collect.py
+++ b/wb/diag/diag_collect.py
@@ -68,7 +68,9 @@ def main(argv=sys.argv):
             print("Start data collecting")
 
             wb_archive_collector = collector.Collector(logger)
-            asyncio.get_event_loop().run_until_complete(wb_archive_collector.collect(options, "", args.output_filename[0]))
+            asyncio.get_event_loop().run_until_complete(
+                wb_archive_collector.collect(options, "", args.output_filename[0])
+            )
 
             print("Data was collected successfully")
 

--- a/wb/diag/rpc_server.py
+++ b/wb/diag/rpc_server.py
@@ -1,11 +1,14 @@
+import asyncio
+import atexit
+import json
 import os
 import signal
 import subprocess
 import sys
-import threading
 from contextlib import contextmanager
 
-from mqttrpc import MQTTRPCResponseManager, dispatcher
+from mqttrpc import dispatcher
+from mqttrpc.manager import AMQTTRPCResponseManager
 from wb_common.mqtt_client import MQTTClient
 
 from wb.diag import collector
@@ -13,35 +16,50 @@ from wb.diag import collector
 EXIT_FAILURE = 1
 
 
-class MQTTRPCServer:
-    def __init__(self, options, dispatcher, logger):  # pylint:disable=redefined-outer-name
+class AsyncMQTTRPCServer:
+    DIAG_ARTIFACT_TOPIC = "/wb-diag-collect/artifact"
+
+    def __init__(self, options, dispatcher, logger, asyncio_loop=asyncio.get_event_loop()):  # pylint:disable=redefined-outer-name
         self.options = options
         self.logger = logger
-        self.dispatcher = dispatcher
         self.driver_id = "diag"
 
-        self.dispatcher.add_method(self.diag)
-        self.dispatcher.add_method(self.status)
+        self.asyncio_loop = asyncio_loop
+        self._setup_event_loop()
 
-        self._stop_event = threading.Event()
+        self.dispatcher = dispatcher
+        self.dispatcher.add_method(self.launch_diag_collect, name="diag")
+        self.dispatcher.add_method(self.status)
 
         broker = options["broker"]
         self.client = MQTTClient("wb-diag-collect", broker)
         logger.debug("Connecting to broker %s", broker)
-        self.client.on_message = self._on_message
-        self.client.on_connect = self._on_connect
-        self.client.start()
-
-        signal.signal(signal.SIGINT, self._signal)
-        signal.signal(signal.SIGTERM, self._signal)
+        self._setup_mqtt_connection()
 
         self.wb_archive_collector = collector.Collector(logger)
+
+        self._diag_collecting_task = None
+
+    def _setup_event_loop(self):
+        signals = [signal.SIGINT, signal.SIGTERM]
+        for sig in signals:
+            self.asyncio_loop.add_signal_handler(sig, lambda: self.asyncio_loop.stop())
+        self.logger.debug("Add handler for: %s; event loop: %s", str(signals), str(self.asyncio_loop))
+
+    def _setup_mqtt_connection(self):
+        self.client.on_message = self._on_message
+        self.client.on_connect = self._on_connect
+        try:
+            self.client.start()
+        finally:
+            atexit.register(lambda: self.client.stop())
 
     def _on_connect(self, _client, _userdata, _flags, rc, *_):
         # write graceful exit here + guideline
         # https://wirenboard.bitrix24.ru/workgroups/group/218/tasks/task/view/55510/
         if rc != 0:
             self.logger.error("MQTT broker connection failed, code %d", rc)
+            self.asyncio_loop.stop()
             sys.exit(EXIT_FAILURE)
 
         self.logger.debug("Settings up RPC endpoints")
@@ -51,24 +69,38 @@ class MQTTRPCServer:
             self.client.subscribe(f"/rpc/v1/{self.driver_id}/{service}/{method}/+")
 
     def _on_message(self, _mosq, _obj, msg):
-        parts = msg.topic.split("/")
-        service_id = parts[4]
-        method_id = parts[5]
-        client_id = parts[6]
+        asyncio.run_coroutine_threadsafe(self.run_async(msg), self.asyncio_loop)
 
-        response = MQTTRPCResponseManager.handle(msg.payload, service_id, method_id, self.dispatcher)
+    async def run_async(self, message):
+        parts = message.topic.split("/")
+        service_id, method_id, client_id = parts[4], parts[5], parts[6]
+
+        ret = await AMQTTRPCResponseManager.handle(  # wraps any exception into json-rpc
+            message.payload, service_id, method_id, self.dispatcher
+        )
 
         self.client.publish(
             f"/rpc/v1/{self.driver_id}/{service_id}/{method_id}/{client_id}/reply",
-            response.json,
+            ret.json,
             False,
         )
 
-    def status(self):
+    def publish_result(self, payload=None):
+        payload = json.dumps(payload) if payload else None
+        self.client.publish(self.DIAG_ARTIFACT_TOPIC, payload=payload, retain=False, qos=1)
+
+    async def launch_diag_collect(self, **kwargs):
+        if self._diag_collecting_task and not self._diag_collecting_task.done():
+            self.logger.warning("Diag collecting task is already running")
+        else:
+            self._diag_collecting_task = self.asyncio_loop.create_task(self.diag(), name="Collect diagnostics (may be long running)")
+        return "Ok"
+
+    async def status(self):
         self.logger.debug("Method 'status' was called")
         return "1"
 
-    def diag(self):
+    async def diag(self):
         try:
             self.logger.debug("Method 'diag' was called")
             try:
@@ -79,25 +111,23 @@ class MQTTRPCServer:
             print("Start data collecting")
 
             wb_archive_collector = collector.Collector(self.logger)
-            path = wb_archive_collector.collect(self.options, "/var/www/diag/", "diag_output")
+            path = await wb_archive_collector.collect(self.options, "/var/www/diag/", "diag_output")
 
             print("Data was collected successfully")
 
-            return {"basename": os.path.basename(path), "fullname": path}
+            self.publish_result(payload={"basename": os.path.basename(path), "fullname": path})
         except OSError as e:
             print("OSError: with file %s, errno %d", e.filename, e.errno)
-            return None
+            self.publish_result(payload=None)
 
-    def wait_for_stop(self):
-        self._stop_event.wait()
-
-    def _signal(self, *_):
-        self.logger.debug("Asynchronous interrupt, stopping")
-        self._stop_event.set()
+    def run(self):
+        self.asyncio_loop.run_forever()
 
     def stop(self):
         try:
             self.logger.debug("Cleaning up retains")
+
+            self.publish_result(payload=None)
 
             pubs = []
             for service, method in self.dispatcher.keys():
@@ -105,14 +135,14 @@ class MQTTRPCServer:
             for pub in pubs:
                 pub.wait_for_publish()
         finally:
-            self.logger.debug("Disconnecting from broker")
             self.client.stop()
+            self.asyncio_loop.stop()
 
 
 @contextmanager
 def rpc_server_context(options, dispatcher, logger):  # pylint:disable=redefined-outer-name
     try:
-        rpc_server = MQTTRPCServer(options, dispatcher, logger)
+        rpc_server = AsyncMQTTRPCServer(options, dispatcher, logger)
         yield rpc_server
     except (TimeoutError, ConnectionRefusedError):
         logger.error("Cannot connect to broker %s", options["broker"], exc_info=True)
@@ -122,4 +152,4 @@ def rpc_server_context(options, dispatcher, logger):  # pylint:disable=redefined
 
 def serve(options, logger):
     with rpc_server_context(options, dispatcher, logger) as server:
-        server.wait_for_stop()
+        server.run()


### PR DESCRIPTION
была проблемка: ТП жаловалась на mqtt_rpc_timeout на старых / загруженных контроллерах

раскопал - причина классическая: долгая операция (сборка диаг-архива) в rpc-хендлере
решение - в хендлере только запускаем таску, а дальше - она сама шуршит => понадобилось завести asyncio


в [веб-морде](https://github.com/wirenboard/homeui/pull/703) поведение не изменилось (кроме излеченного таймаута); содержание диаг-архива тоже вроде адекватное