### PR TITLE
Fix services logs collection

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-diag-collect (1.9.1) stable; urgency=medium
+
+  * Fix services logs collection
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 27 Feb 2024 17:19:00 +0400
+
 wb-diag-collect (1.9.0) stable; urgency=medium
 
   * Rework internals to asyncio

--- a/wb/diag/collector.py
+++ b/wb/diag/collector.py
@@ -134,7 +134,7 @@ class Collector:
         env["LC_ALL"] = "C"
 
         proc = await asyncio.create_subprocess_shell(
-            cmd="systemctl list-unit-files --no-pager | grep .service",
+            cmd="systemctl list-units --type=service --state=loaded --no-pager --plain | grep .service",
             env=env,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,


### PR DESCRIPTION
Before:
```sh
wb-diag-collect out1
unzip -l out1_ART6EV6D_2025-02-27-13.16.43.zip | grep service | awk '{print $4}' > list1
```

After:
```sh
wb-diag-collect out2
unzip -l out2_ART6EV6D_2025-02-27-13.18.36.zip | grep service | awk '{print $4}' > list2
```

Compare:
```diff
diff -Naur list1 list2
--- list1	2025-02-27 13:30:03.259554255 +0000
+++ list2	2025-02-27 13:30:10.409533102 +0000
@@ -5,17 +5,15 @@
 service/wb-mqtt-iec104.service.log
 service/wb-knxd-config.service.log
 service/wb-usb-otg.service.log
-service/wb-cloud-agent-telegraf@.service.log
 service/systemd_units.log
 service/wb-rules.service.log
 service/wb-mqtt-nm-helper.service.log
 service/wb-cloud-agent-telegraf.service.log
 service/wb-prepare.service.log
 service/wb-gsm.service.log
+service/wb-cloud-agent-telegraf@staging.service.log
 service/hostapd.service.log
 service/wb-systime-adjust.service.log
-service/wb-cloud-agent-frpc@.service.log
-service/wb-cloud-agent@.service.log
 service/wpa_supplicant.service.log
 service/wb-mqtt-opcua.service.log
 service/wb-mqtt-db.service.log
@@ -23,21 +21,22 @@
 service/wb-mqtt-metrics.service.log
 service/wb-configs-early.service.log
 service/wb-mqtt-w1.service.log
-service/wb-homa-adc.service.log
 service/wb-device-manager.service.log
 service/wb-mqtt-knx.service.log
 service/wb-mqtt-gpio.service.log
 service/wb-mqtt-logs.service.log
 service/mosquitto.service.log
+service/wb-cloud-agent@local.service.log
 service/wb-mqtt-snmp.service.log
 service/wb-configs.service.log
+service/wb-cloud-agent-frpc@staging.service.log
 service/ModemManager.service.log
 service/wb-cloud-agent-frpc.service.log
 service/wb-mqtt-serial.service.log
 service/wb-mqtt-urri.service.log
+service/wb-cloud-agent@staging.service.log
 service/systemd_unit_files.log
 service/NetworkManager.service.log
-service/wb-homa-w1.service.log
 service/wb-hwconf-manager.service.log
 service/wb-mqtt-mbgate.service.log
 service/wb-mqtt-adc.service.log
@@ -47,4 +46,3 @@
 service/wb-cloud-agent.service.log
 service/journalctl_list_boots.log
 service/wb-watch-update.service.log
-service/wb-homa-gpio.service.log
```