### PR TITLE
Fix package dependencies

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-diag-collect (1.9.0-wb100) stable; urgency=medium
+
+  * Fix package dependencies
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 04 Mar 2025 19:03:25 +0500
+
 wb-diag-collect (1.9.0) stable; urgency=medium
 
   * Rework internals to asyncio

--- a/debian/control
+++ b/debian/control
@@ -21,6 +21,6 @@ Breaks: python3-wb-diag-collect (<< 1.7.0)
 Replaces: python3-wb-diag-collect (<< 1.7.0)
 Provides: python3-wb-diag-collect
 Depends: ${misc:Depends}, ${python3:Depends}, python3-yaml, python3-mqttrpc, python3-wb-common (>= 2.1.0), emmcparm (>= 5.0.0), mqtt-tools
-Recommends: wb-mqtt-homeui (>= 2.111.0~~)
+Recommends: wb-mqtt-homeui (>= 2.107.7-wb101)
 Description: one-click diagnostic data collector for Wiren Board,
  generating archive with data


### PR DESCRIPTION
Пакет рекомендовал wb-homeui 2.111.0 и выше, но этого пакета нет в wb-2501. В результате пакет не устанавливался по `apt upgrade`
```
root@wirenboard-APT6KWYK:~# apt update && apt upgrade
Hit:1 http://debian-mirror.wirenboard.com/debian bullseye InRelease       
Hit:2 http://debian-mirror.wirenboard.com/debian bullseye-updates InRelease
Hit:3 http://debian-mirror.wirenboard.com/debian bullseye-backports InRelease
Hit:4 http://deb.wirenboard.com/wb7/bullseye stable InRelease
Hit:5 http://debian-mirror.wirenboard.com/debian-security bullseye-security InRelease
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
14 packages can be upgraded. Run 'apt list --upgradable' to see them.
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Calculating upgrade... Done
The following packages have been kept back:
  wb-diag-collect
The following packages will be upgraded:
  libgnutls-openssl27 libgnutls30 libgssapi-krb5-2 libk5crypto3 libkrb5-3 libkrb5support0 libtasn1-6 libxml2 linux-image-wb7 linux-libc-dev
  wb-mqtt-homeui wb-mqtt-serial wb-release-info
13 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
Need to get 0 B/33,1 MB of archives.
After this operation, 62,5 kB of additional disk space will be used.
```