### PR TITLE
Fix lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,15 @@
+wb-diag-collect (1.9.2) stable; urgency=medium
+
+  * Fix lintian
+  * Adopt PEP440
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 24 Apr 2025 17:19:00 +0400
+
 wb-diag-collect (1.9.1) stable; urgency=medium
 
   * Fix services logs collection
 
- -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 27 Feb 2024 17:19:00 +0400
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 27 Feb 2025 17:19:00 +0400
 
 wb-diag-collect (1.9.0) stable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -5,14 +5,7 @@ Maintainer: Wiren Board Team <info@wirenboard.com>
 Build-Depends: debhelper (>= 10), dh-python, python3-all, python3-setuptools, python3-pytest, python3-tomli, python3-yaml, pkg-config
 Standards-Version: 4.5.0
 Homepage: https://github.com/wirenboard/wb-diag-collect
-X-Python3-Version: >= 3.5
-
-Package: python3-wb-diag-collect
-Section: python
-Architecture: all
-Depends: wb-diag-collect (>= 1.7.0)
-Description: transitional dummy package
- This is a transitional dummy package. It can safely be removed.
+X-Python3-Version: >= 3.9
 
 Package: wb-diag-collect
 Architecture: all
@@ -22,5 +15,5 @@ Replaces: python3-wb-diag-collect (<< 1.7.0)
 Provides: python3-wb-diag-collect
 Depends: ${misc:Depends}, ${python3:Depends}, python3-yaml, python3-mqttrpc, python3-wb-common (>= 2.1.0), emmcparm (>= 5.0.0), mqtt-tools
 Recommends: wb-mqtt-homeui (>= 2.111.0~~)
-Description: one-click diagnostic data collector for Wiren Board,
- generating archive with data
+Description: Wirenboard collector of data and logs
+ one-click diagnostic data collector for Wiren Board, generating archive with data.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 def get_version():
     with open("debian/changelog", "r", encoding="utf-8") as f:
-        return f.readline().split()[1][1:-1]
+        return f.readline().split()[1][1:-1].split("~")[0]
 
 
 setup(


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
* Fix lintian
* Adopt PEP 440 (for debian 13)
* Drop transitional python3-wb-diag-collect

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


