### PR TITLE
Add network-test

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-diag-collect (1.9.6) stable; urgency=medium
+
+  * Add network-test
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Wed, 18 Mar 2026 17:19:00 +0400
+
 wb-diag-collect (1.9.5) stable; urgency=medium
 
   * Add /var/lib/wb-mqtt-adc/conf.d/system.conf and /var/lib/wb-mqtt-gpio/conf.d/system.conf to files

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,13 @@ Source: wb-diag-collect
 Section: misc
 Priority: optional
 Maintainer: Wiren Board Team <info@wirenboard.com>
-Build-Depends: debhelper (>= 10), dh-python, python3-all, python3-setuptools, python3-pytest, python3-tomli, python3-yaml, pkg-config
+Build-Depends: debhelper (>= 10),
+               dh-python,
+               python3-all,
+               python3-setuptools,
+               python3-pytest,
+               python3-tomli,
+               python3-yaml
 Standards-Version: 4.5.0
 Homepage: https://github.com/wirenboard/wb-diag-collect
 X-Python3-Version: >= 3.9
@@ -13,7 +19,15 @@ Multi-Arch: foreign
 Breaks: python3-wb-diag-collect (<< 1.7.0)
 Replaces: python3-wb-diag-collect (<< 1.7.0)
 Provides: python3-wb-diag-collect
-Depends: ${misc:Depends}, ${python3:Depends}, python3-yaml, python3-mqttrpc, python3-wb-common (>= 2.1.0), emmcparm (>= 5.0.0), mqtt-tools
+Depends: ${misc:Depends},
+         ${python3:Depends},
+         python3-yaml,
+         python3-mqttrpc,
+         python3-wb-common (>= 2.1.0),
+         curl,
+         emmcparm (>= 5.0.0),
+         jq,
+         mqtt-tools
 Recommends: wb-mqtt-homeui (>= 2.111.0~~)
 Description: Wirenboard collector of data and logs
  one-click diagnostic data collector for Wiren Board, generating archive with data.

--- a/wb-diag-collect.conf
+++ b/wb-diag-collect.conf
@@ -114,6 +114,9 @@ commands:
       filename: nmcli
       command: 'nmcli'
     -
+      filename: network-test
+      command: jq -r '.connectivity_check_url // "http://network-test.debian.org/nm"' /etc/wb-connection-manager.conf | xargs -r curl -fsS
+    -
       filename: wb-ec/fwrev
       command: 'cat /sys/bus/spi/drivers/wbec/spi0.0/fwrev'
     -


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Проверка доступа в интернет, таким же способом проверяет connection-manager, но сейчас нет удобной ручки, чтобы получить статус прямо из него, только если проверять Connectivity контрол у активных system__networks__* девайсов.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
локально

