### PR TITLE
Collect pstore/ramoops panic logs in the diagnostic archive

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-diag-collect (1.10.2) stable; urgency=medium
+
+  * Collect pstore/ramoops panic logs (/sys/fs/pstore, /var/lib/systemd/pstore)
+
+ -- Wiren Board Robot <info@wirenboard.com>  Fri, 04 Jul 2026 14:30:00 +0300
+
 wb-diag-collect (1.10.1) stable; urgency=medium
 
   * Add /etc/wb-mqtt-snmp.conf

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
 wb-diag-collect (1.10.2) stable; urgency=medium
 
-  * Collect pstore/ramoops panic logs (/sys/fs/pstore, /var/lib/systemd/pstore)
+  * Collect pstore/ramoops panic logs and post-crash recovery markers, from the
+    archived records (/sys/fs/pstore, /var/lib/systemd/pstore) and the journal
 
- -- Wiren Board Robot <info@wirenboard.com>  Fri, 04 Jul 2026 14:30:00 +0300
+ -- Evgeny Boger <boger@wirenboard.com>  Thu, 09 Jul 2026 14:55:24 +0300
 
 wb-diag-collect (1.10.1) stable; urgency=medium
 

--- a/wb-diag-collect.conf
+++ b/wb-diag-collect.conf
@@ -57,6 +57,9 @@ commands:
       filename: uptime
       command: uptime
     -
+      filename: pstore
+      command: 'journalctl -u systemd-pstore -o cat --output-fields=FILE --no-pager | tail -c 1000000'
+    -
       filename: service/journalctl_list_boots
       command: 'journalctl --list-boots'
     -
@@ -145,6 +148,10 @@ commands:
       command: 'cat /sys/kernel/debug/gpio'
 
 files:
+    # pstore/ramoops: kernel panic logs and console tail that survived a
+    # warm reboot (harvested by systemd-pstore on boot + not-yet-harvested)
+    - /var/lib/systemd/pstore/*
+    - /sys/fs/pstore/*
     - /etc/apt/sources.list*
     - /etc/apt/preferences*
     - /etc/mosquitto/mosquitto.conf

--- a/wb-diag-collect.conf
+++ b/wb-diag-collect.conf
@@ -60,6 +60,9 @@ commands:
       filename: pstore
       command: 'journalctl -u systemd-pstore -o cat --output-fields=FILE --no-pager | tail -c 1000000'
     -
+      filename: pstore-recovery-history
+      command: 'journalctl --no-pager -o short-iso -n 5000 | grep -aiE "wb_ramoops_panic_reset|came back from a panic|not re-arming"'
+    -
       filename: service/journalctl_list_boots
       command: 'journalctl --list-boots'
     -
@@ -148,10 +151,6 @@ commands:
       command: 'cat /sys/kernel/debug/gpio'
 
 files:
-    # pstore/ramoops: kernel panic logs and console tail that survived a
-    # warm reboot (harvested by systemd-pstore on boot + not-yet-harvested)
-    - /var/lib/systemd/pstore/*
-    - /sys/fs/pstore/*
     - /etc/apt/sources.list*
     - /etc/apt/preferences*
     - /etc/mosquitto/mosquitto.conf
@@ -185,6 +184,12 @@ files:
     - /etc/group-
     - /var/lib/wb-mqtt-gpio/conf.d/system.conf
     - /var/lib/wb-mqtt-adc/conf.d/system.conf
+    # pstore/ramoops: kernel panic logs and console tail that survived a
+    # warm reboot (harvested by systemd-pstore on boot + not-yet-harvested).
+    # Kept last: these RAM-backed pseudo-files are the most likely to fail a
+    # copy, and copy_files aborts the whole run on the first error.
+    - /var/lib/systemd/pstore/*
+    - /sys/fs/pstore/*
 
 filters:
     -


### PR DESCRIPTION
Include kernel panic / crash logs (pstore/ramoops) in the diagnostic archive, so a crash is visible to support.

## What it collects
- **The raw records** — copies the archived ramoops dumps: `/var/lib/systemd/pstore/*` (dmesg + console) and `/sys/fs/pstore/*` (anything not yet archived). Full backtrace of the most recent crash.
- **`pstore`** — `journalctl -u systemd-pstore --output-fields=FILE`: systemd-pstore logs each harvested record's full content to the journal, so this pulls the crash backtraces across **all retained boots**, not just the latest one the files hold.
- **`pstore-recovery-history`** — a bounded journal grep (`-n 5000`) for the panic-reset / loop-brake markers (`wb_ramoops_panic_reset`, "came back from a panic", "not re-arming") — the post-crash recovery narrative across recent boots.

## Notes
- The pstore file globs are placed **last** in `files:` deliberately: `copy_files` runs first and aborts the whole collection on the first failed copy, and the RAM-backed `/sys/fs/pstore` pseudo-files are the most likely to fail — so they must not precede the config/command/journal collection.
- The recovery grep is a bounded backward read (no whole-journal scan), staying well within the per-command timeout.
- Verified end to end on WB8 hardware: a produced archive contains the two raw `*-ramoops-0` records plus `pstore.log` and `pstore-recovery-history.log`.
