### PR TITLE
Increase wb-release log lines count to 5000

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-diag-collect (1.10.2) stable; urgency=medium
+
+  * Increase wb-release log lines count to 5000
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 21 Jul 2026 15:35:00 +0400
+
 wb-diag-collect (1.10.1) stable; urgency=medium
 
   * Add /etc/wb-mqtt-snmp.conf

--- a/wb-diag-collect.conf
+++ b/wb-diag-collect.conf
@@ -97,7 +97,7 @@ commands:
       command: 'emmcparm -I /dev/mmcblk0'
     -
       filename: wb-release
-      command: 'journalctl -t wb-release -n 1000 --no-pager'
+      command: 'journalctl -t wb-release -n 5000 --no-pager'
     -
       filename: serialnumber
       command: 'wb-gen-serial -s'


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
При обновлении с булзая на трикси полный лог wb-release больше 4000 строк, сейчас собирается только 1000, что затрудняет траблшутинг.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


